### PR TITLE
fix: insync function comparing current and should items

### DIFF
--- a/lib/puppet/provider/alternative/rhel.rb
+++ b/lib/puppet/provider/alternative/rhel.rb
@@ -118,11 +118,13 @@ Puppet::Type.type(:alternative).provide(:rhel) do
     alternatives_file.shift
     while !alternatives_file.empty? do 
       slave_name = alternatives_file.shift.strip
-      if slave_name =~ /^$/m
-        break
-      end
+      break if slave_name =~ /^$/m
+
+      slave_path = fetch_slave_path(slave_paths, slave_name)
+      break if slave_path =~ /^[(]null[)]$/
+
       slave_link = alternatives_file.shift.strip
-      slave_path = fetch_slave_path(slave_paths, slave_name) 
+
       slave_hash = { 'link' => slave_link, 'name' => slave_name, 'path' => slave_path }
       slaveparams.push(slave_hash)
     end

--- a/lib/puppet/type/alternative.rb
+++ b/lib/puppet/type/alternative.rb
@@ -49,13 +49,11 @@ Puppet::Type.newtype(:alternative) do
       if current_array.size != should_array.size
         return false
       end
-      current_array.each_with_index do |item, index|
-        # Because hashes are not yet 'sorted' in ruby 1.8: call the sort method
-        # To convert to 'sorted' array:
-        if item.sort != should_array[index].sort
-          return false
-        end
+
+      current_array.each do |e|
+        return false unless @should.include?e
       end
+
       return true
     end
   end


### PR DESCRIPTION
- insync function did not work properly in our setup (we had to manipulate slaves data coming from hiera). Inspite of the sort function the items order in  current and should arrays was different and it made puppet to perform a change each time puppet run was performed.
  This fix helps compare both array disregard the items order
- The second commit is to avoid annoying puppet messages to modify alternatives when no slave were set:
  (null) -> ''
  In fact nothing changes, so if a slave is not set and is shown as "(null)" by alternatives --display
  puppet should ignore this
